### PR TITLE
Fix syntax error from misplaced Streamlit import

### DIFF
--- a/main.py
+++ b/main.py
@@ -988,7 +988,9 @@ if __name__ == "__main__":
         st.info("💡 Instala con: pip install streamlit pandas plotly prophet openpyxl")
     except Exception as e:
         st.error(f"❌ Error inesperado: {str(e)}")
-        st.info("🔄 Recarga la página para reiniciar")import streamlit as st
+        st.info("🔄 Recarga la página para reiniciar")
+
+import streamlit as st
 import pandas as pd
 import numpy as np
 import plotly.express as px


### PR DESCRIPTION
## Summary
- fix invalid syntax by separating the Streamlit import

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d5fa604ec8321b55f4b8dc17dd0ea