### PR TITLE
Fix string termination and restore matching results UI

### DIFF
--- a/main.py
+++ b/main.py
@@ -2265,5 +2265,20 @@ def mostrar_paso_4_seleccion_manual():
             
             if opciones_disponibles is not None and len(opciones_disponibles) > 0:
                 st.session_state['opciones_disponibles'] = opciones_disponibles
-                st.session_state['config_matching'] = config_matching  # Guardar config
-                st.success(f"✅
+                st.session_state['config_matching'] = config_matching  # Guardar config                st.success(
+                    f"✅ {len(opciones_disponibles)} opciones encontradas con algoritmo mejorado"
+                )
+
+                # Mostrar estadísticas de matching
+                mostrar_estadisticas_matching(opciones_disponibles)
+
+                # Mostrar interfaz de selección
+                mostrar_interfaz_seleccion_manual(opciones_disponibles, distribucion)
+            else:
+                st.error("❌ No se encontraron opciones compatibles")
+                mostrar_debugging_opciones_mejorado(distribucion, df_proveedor, config_matching)
+
+    # Si ya hay opciones disponibles, mostrar la interfaz
+    if 'opciones_disponibles' in st.session_state:
+        opciones = st.session_state['opciones_disponibles']
+        mostrar_interfaz_seleccion_manual(opciones, distribucion)


### PR DESCRIPTION
## Summary
- close an unterminated string in `main.py`
- restore missing logic that shows matching results and stats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d61ff3dec8321a5d7137927040385